### PR TITLE
find_package(Protobuf...) added to CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(GameNetworkingSockets CONFIG REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(BZip2 REQUIRED)
 find_package(PNG REQUIRED)
+find_package(Protobuf REQUIRED)
 
 include(cmake/CPM.cmake)
 


### PR DESCRIPTION
This solves the issue of Protobuf missing when trying to build the game without vcpkg.